### PR TITLE
Fixed typo (cylinder instead of cylinder)

### DIFF
--- a/openscad.tmLanguage
+++ b/openscad.tmLanguage
@@ -292,7 +292,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(cube|cylindeer|polyhedron|sphere)\b</string>
+					<string>\b(cube|cylinder|polyhedron|sphere)\b</string>
 					<key>name</key>
 					<string>support.function.primitives.scad</string>
 				</dict>


### PR DESCRIPTION
Hi,

Thanks for your Sublime package!

This fixes a typo in openscad.tmLanguage at line 295:
(cylinder instead of cylinder)
