### PR TITLE
added build options (export to png/dxf/stl)

### DIFF
--- a/Openscad.sublime-build
+++ b/Openscad.sublime-build
@@ -5,13 +5,25 @@
 	"variants":
   	[
   		{
-	      	"name": "PNG",
-			"cmd": ["openscad -o 1.png ${file}"],	    },
+	      	"name": "PNG - linux",
+			"cmd": ["openscad -o ${file/(.+)\\..+/$1/}.png ${file}"],	    },
 	    {
-	      	"name": "DXF",
-			"cmd": ["openscad -o 1.dxf ${file}"],		},
+	      	"name": "DXF - linux",
+			"cmd": ["openscad -o ${file/(.+)\\..+/$1/}.dxf ${file}"],		},
 	    {
-	      	"name": "STL",
-			"cmd": ["openscad -o 1.stl ${file}"],		}
+	      	"name": "STL - linux",
+			"cmd": ["openscad -o ${file/(.+)\\..+/$1/}.stl ${file}"],		},
+  		{
+	      	"name": "PNG - windows",
+  	    	"path": "C:\\Program Files\\OpenSCAD",
+			"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.png", "${file}"],	    },
+	    {
+	      	"name": "DXF - windows",
+  	    	"path": "C:\\Program Files\\OpenSCAD",
+			"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.dxf", "${file}"],		},
+	    {
+	      	"name": "STL - windows",
+  	    	"path": "C:\\Program Files\\OpenSCAD",
+			"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.stl", "${file}"],		}
 	]
 }

--- a/Openscad.sublime-build
+++ b/Openscad.sublime-build
@@ -1,0 +1,17 @@
+{
+	"shell": true,
+	"cmd": ["openscad ${file}"],
+	"path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
+	"variants":
+  	[
+  		{
+	      	"name": "PNG",
+			"cmd": ["openscad -o 1.png ${file}"],	    },
+	    {
+	      	"name": "DXF",
+			"cmd": ["openscad -o 1.dxf ${file}"],		},
+	    {
+	      	"name": "STL",
+			"cmd": ["openscad -o 1.stl ${file}"],		}
+	]
+}


### PR DESCRIPTION
linux tested only, png requires newish version of openscad. saves to a file in the same folder 