### PR TITLE
Add \b to true, false, undef, PI literal matches.

### DIFF
--- a/openscad.YAML-tmLanguage
+++ b/openscad.YAML-tmLanguage
@@ -47,13 +47,13 @@ repository:
   literals:
     patterns:
     - name: constant.language.boolean.true.scad
-      match: 'true'
+      match: '\btrue\b'
     - name: constant.language.boolean.false.scad
-      match: 'false'
+      match: '\bfalse\b'
     - name: constant.language.boolean.undef.scad
-      match: 'undef'
+      match: '\bundef\b'
     - name: constant.language.boolean.PI.scad
-      match: 'PI'
+      match: '\bPI\b'
     - name: string.quoted.double.scad
       begin: '"'
       end: '"'

--- a/openscad.tmLanguage
+++ b/openscad.tmLanguage
@@ -127,25 +127,25 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>true</string>
+					<string>\btrue\b</string>
 					<key>name</key>
 					<string>constant.language.boolean.true.scad</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>false</string>
+					<string>\bfalse\b</string>
 					<key>name</key>
 					<string>constant.language.boolean.false.scad</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>undef</string>
+					<string>\bundef\b</string>
 					<key>name</key>
 					<string>constant.language.boolean.undef.scad</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>PI</string>
+					<string>\bPI\b</string>
 					<key>name</key>
 					<string>constant.language.boolean.pi.scad</string>
 				</dict>


### PR DESCRIPTION
This prevents variable names with these substrings from becoming partially colorized.

Thank you for making this tmlang!