### PR TITLE
(rough draft) Highlight parameters of multi-line module, function signatures.

### DIFF
--- a/openscad.YAML-tmLanguage
+++ b/openscad.YAML-tmLanguage
@@ -10,6 +10,9 @@ patterns:
 - include: '#keywords'
 - include: '#literals'
 - include: '#support'
+- include: '#modules'
+- include: '#functions'
+- include: '#function-call'
 
 repository:
   comments:
@@ -44,6 +47,60 @@ repository:
     - name: keyword.operator.conditional.scad
       match: \?
 
+  keyword_arguments:
+    begin: \b([[:alpha:]_][[:alnum:]_]*)\s*(=)(?!=)
+    beginCaptures:
+      '1': {name: variable.parameter.function.keyword.scad}
+      '2': {name: keyword.operator.assignment.scad}
+    end: \s*(?:(,)|(?=[\)\:]))
+    endCaptures:
+      '1': {name: punctuation.separator.parameters.scad}
+    patterns:
+    - include: $self
+
+  modules:
+    contentName: meta.module.parameters.scad
+    begin: \b(module)\s+([[:alpha:]_][[:alnum:]_]*)\s*(\()
+    beginCaptures:
+      '1': { name: storage.modifier.module.scad }
+      '2': { name: entity.name.function.scad }
+      '3': { name: punctuation.definition.parameters.begin.scad }
+    end: (\))
+    endCaptures:
+      '1': { name: punctuation.definition.parameters.end.scad }
+    patterns:
+      - include: '#keyword_arguments'
+      - name: variable.parameter.scad
+        match: ([[:alpha:]_][[:alnum:]_]*)
+
+  functions:
+    contentName: meta.function.parameters.scad
+    begin: \b(function)\s+([[:alpha:]_][[:alnum:]_]*)\s*(\()
+    beginCaptures:
+      '1': { name: storage.modifier.function.scad }
+      '2': { name: entity.name.function.scad }
+      '3': { name: punctuation.definition.parameters.begin.scad }
+    end: (\))
+    endCaptures:
+      '1': { name: punctuation.definition.parameters.end.scad }
+    patterns:
+      - include: '#keyword_arguments'
+      - name: variable.parameter.scad
+        match: ([[:alpha:]_][[:alnum:]_]*)
+
+  function-call:
+    name: meta.function-call.scad
+    contentName: meta.function-call.arguments.scad
+    begin: (\()
+    beginCaptures:
+      '1': {name: punctuation.definition.arguments.begin.scad}
+    end: (\))
+    endCaptures:
+      '1': {name: punctuation.definition.arguments.end.scad}
+    patterns:
+    - include: '#keyword_arguments'
+    - include: $self
+
   literals:
     patterns:
     - name: constant.language.boolean.true.scad
@@ -62,34 +119,12 @@ repository:
       - match: \\.
     - name: constant.numeric.scad
       match: \b(\d+(\.\d+)?)\b
-    - name: meta.module.scad
-      match: \b(module|function)\s+([\w\d]*)\s*(\()([^\)]*)(\))
-      captures:
-        '1': { name: storage.modifier.module.scad }
-        '2': { name: entity.name.function.scad }
-        '3': { name: punctuation.definition.parameters.begin.scad }
-        '4': { name: variable.parameter.module.scad }
-        '5': { name: punctuation.definition.parameters.end.scad }
     - name: meta.module.children.scad
       match: \b(children)\s*(\()(.*?)(\))
       captures:
         '1': { name: storage.modifier.module.scad }
         '2': { name: punctuation.definition.parameters.begin.scad }
         '4': { name: punctuation.definition.parameters.end.scad }
-    - name: meta.function.scad
-      begin: \b(function)\s+([\w\d]*)\s*(\()(.*?)(\))\s*=
-      beginCaptures:
-        '1': { name: storage.modifier.function.scad }
-        '2': { name: entity.name.function.scad }
-        '3': { name: punctuation.definition.parameters.begin.scad }
-        '4': { name: variable.parameter.function.scad }
-        '5': { name: punctuation.definition.parameters.end.scad }
-      patterns:
-      - include: $self
-      - use: $self
-      - name: meta.body.scad
-      - match: .*?
-      end: ;
     - name: variable.parameter.special.scad
       match: \B\$(fa|fs|fn|t|vpr|vpt|vpd|children|preview)\b
 

--- a/openscad.tmLanguage
+++ b/openscad.tmLanguage
@@ -26,6 +26,18 @@
 			<key>include</key>
 			<string>#support</string>
 		</dict>
+		<dict>
+			<key>include</key>
+			<string>#modules</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#functions</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#function-call</string>
+		</dict>
 	</array>
 	<key>repository</key>
 	<dict>
@@ -64,6 +76,127 @@
 					<string>\*/</string>
 					<key>name</key>
 					<string>comment.block.scad</string>
+				</dict>
+			</array>
+		</dict>
+		<key>function-call</key>
+		<dict>
+			<key>begin</key>
+			<string>(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.arguments.begin.scad</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>meta.function-call.arguments.scad</string>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.arguments.end.scad</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.function-call.scad</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#keyword_arguments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<key>functions</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(function)\s+([[:alpha:]_][[:alnum:]_]*)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.function.scad</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.scad</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.begin.scad</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>meta.function.parameters.scad</string>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.end.scad</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#keyword_arguments</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([[:alpha:]_][[:alnum:]_]*)</string>
+					<key>name</key>
+					<string>variable.parameter.scad</string>
+				</dict>
+			</array>
+		</dict>
+		<key>keyword_arguments</key>
+		<dict>
+			<key>begin</key>
+			<string>\b([[:alpha:]_][[:alnum:]_]*)\s*(=)(?!=)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.parameter.function.keyword.scad</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.assignment.scad</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>\s*(?:(,)|(?=[\)\:]))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.parameters.scad</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
@@ -147,7 +280,7 @@
 					<key>match</key>
 					<string>\bPI\b</string>
 					<key>name</key>
-					<string>constant.language.boolean.pi.scad</string>
+					<string>constant.language.boolean.PI.scad</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -185,40 +318,6 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.scad</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.begin.scad</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.module.scad</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.end.scad</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>\b(module|function)\s+([\w\d]*)\s*(\()(.*?)(\))</string>
-					<key>name</key>
-					<string>meta.module.scad</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.module.scad</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
 							<string>punctuation.definition.parameters.begin.scad</string>
 						</dict>
 						<key>4</key>
@@ -233,65 +332,58 @@
 					<string>meta.module.children.scad</string>
 				</dict>
 				<dict>
-					<key>begin</key>
-					<string>\b(function)\s+([\w\d]*)\s*(\()(.*?)(\))\s*=</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.function.scad</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.scad</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.begin.scad</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>variable.parameter.function.scad</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.end.scad</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>;</string>
-					<key>name</key>
-					<string>meta.function.scad</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-						<dict>
-							<key>use</key>
-							<string>$self</string>
-						</dict>
-						<dict>
-							<key>name</key>
-							<string>meta.body.scad</string>
-						</dict>
-						<dict>
-							<key>match</key>
-							<string>.*?</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
 					<key>match</key>
 					<string>\B\$(fa|fs|fn|t|vpr|vpt|vpd|children|preview)\b</string>
 					<key>name</key>
 					<string>variable.parameter.special.scad</string>
+				</dict>
+			</array>
+		</dict>
+		<key>modules</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(module)\s+([[:alpha:]_][[:alnum:]_]*)\s*(\()</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.module.scad</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function.scad</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.begin.scad</string>
+				</dict>
+			</dict>
+			<key>contentName</key>
+			<string>meta.module.parameters.scad</string>
+			<key>end</key>
+			<string>(\))</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.end.scad</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#keyword_arguments</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([[:alpha:]_][[:alnum:]_]*)</string>
+					<key>name</key>
+					<string>variable.parameter.scad</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Hi,

I wanted to improve the syntax so that it would highlight the parameters inside a multi-line module signature. Before these changes, multi-line modules were unhighlighted or wrongly highlighted:

![2021-08-30_23-19-02](https://user-images.githubusercontent.com/7299570/131452057-6474fad0-0245-411b-8cc4-a52fa8ddc2f7.png)

Now they look like this:

![2021-08-30_23-19-12](https://user-images.githubusercontent.com/7299570/131452058-379ab3d3-1a35-4153-b75f-a9712c7e9ac1.png)

**HOWEVER**, I am quite sure I made some collateral damage in the sense that the original patterns captured the entire module/function definitions, and my patterns are more focused on getting the delimiters to highlight the stuff in the middle. I am really bad at understanding these tmlangs and basically copied some of Python's and then banged my head against the wall until it barely worked. I'm making this pull request to introduce the topic but if you close this and rewrite it yourself that'd be totally great with me.

Thanks very much for your time and effort.