### PR TITLE
Fixes: File paths with space characters on macOS cannot be opened by the build command.

### DIFF
--- a/Openscad.sublime-build
+++ b/Openscad.sublime-build
@@ -1,66 +1,63 @@
 {
-  "shell": true,
-  "file_patterns": ["*.scad"],
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
+	"file_patterns": ["*.scad"],
+
+	"osx": {
+		"cmd": ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "$file"],
+	},
+	"linux": {
+		"cmd": [ "openscad", "$file" ],
+	},
+	"windows": {
+		"cmd": ["openscad.com", "$file"],
+	},
 
 
-  "osx": {
-    "cmd": ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD $file"],
-  },
-  "linux": {
-    "cmd": [ "openscad $file" ],
-  },
-  "windows": {
-    "cmd": ["openscad.com $file"],
-  },
-
-
-  "variants": [
-    {
-      "name": "PNG",
-      "osx": {
-        "cmd": [
-          "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD -o ${file/(.+)\\..+/$1/}.png $file"
-        ],
-      },
-      "linux": {
-        "cmd": [
-          "openscad -o ${file/(.+)\\..+/$1/}.png ${file}"
-        ],
-      },
-      "windows": {
-        "cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.png", "${file}"],
-      }
-    }, {
-      "name": "DXF",
-      "osx": {
-        "cmd": [
-          "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD -o ${file/(.+)\\..+/$1/}.dxf $file"
-        ],
-      },
-      "linux": {
-        "cmd": [
-          "openscad -o ${file/(.+)\\..+/$1/}.dxf ${file}"
-        ],
-      },
-      "windows": {
-        "cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.dxf", "${file}"],
-      }
-    }, {
-      "name": "STL",
-      "osx": {
-        "cmd": [
-          "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD -o ${file/(.+)\\..+/$1/}.stl $file"
-        ],
-      },
-      "linux": {
-        "cmd": [
-          "openscad -o ${file/(.+)\\..+/$1/}.stl ${file}"
-        ],
-      },
-      "windows": {
-        "cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.stl", "${file}"],
-      }
-    }
-  ]
+	"variants": [
+		{
+			"name": "PNG",
+			"osx": {
+				"cmd": [
+					"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "${file/(.+)\\..+/$1/}.png", "$file"
+				],
+			},
+			"linux": {
+				"cmd": [
+					"openscad", "-o", "${file/(.+)\\..+/$1/}.png", "$file"
+				],
+			},
+			"windows": {
+				"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.png", "$file"],
+			}
+		}, {
+			"name": "DXF",
+			"osx": {
+				"cmd": [
+					"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "${file/(.+)\\..+/$1/}.dxf", "$file"
+				],
+			},
+			"linux": {
+				"cmd": [
+					"openscad", "-o", "${file/(.+)\\..+/$1/}.dxf", "$file"
+				],
+			},
+			"windows": {
+				"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.dxf", "$file"],
+			}
+		}, {
+			"name": "STL",
+			"osx": {
+				"cmd": [
+					"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "${file/(.+)\\..+/$1/}.stl", "$file"
+				],
+			},
+			"linux": {
+				"cmd": [
+					"openscad", "-o", "${file/(.+)\\..+/$1/}.stl", "$file"
+				],
+			},
+			"windows": {
+				"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.stl", "$file"],
+			}
+		}
+	]
 }


### PR DESCRIPTION
Closes #10 

Convert `shell` style execution strings to pure `cmd` array execution.

The `cmd` array style of definition handles issues like this, where an arbitrary path handled by SublimeText or the OS are properly escaped or handled in the execution.

The `"shell":True` key appears to be a presently undocumented feature of the build system to have the `cmd` key interpreted in the current shell-string mode. If that is the desired behavior, then the proper key is `shell_cmd` followed by a string for execution.

This PR drops the mentioned key, and converts all of the `"cmd":["/path/to/bin argument1 argument2"]` anti-pattern to the documented pattern of `"cmd":["/path/to/bin", "argument1", "argument2"]`. Also, the `path` key is dropped, as that should be a User settings configuration, not built into the plugin. This style of defining a command via an array mirrors other projects such as Docker.

I have tested this change on macOS 15.3.2 and SublimeText stable build 4192. I believe that the similar changes to the Linux and Windows changes are in line with the official documentation, but I have not tested those personally.

[Build System Documentation](https://www.sublimetext.com/docs/build_systems.html)