### PR TITLE
Convert `shell` style execution strings to pure `cmd` array execution.

### DIFF
--- a/Openscad.sublime-build
+++ b/Openscad.sublime-build
@@ -1,66 +1,63 @@
 {
-  "shell": true,
-  "file_patterns": ["*.scad"],
-  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin",
+	"file_patterns": ["*.scad"],
+
+	"osx": {
+		"cmd": ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "$file"],
+	},
+	"linux": {
+		"cmd": [ "openscad", "$file" ],
+	},
+	"windows": {
+		"cmd": ["openscad.com", "$file"],
+	},
 
 
-  "osx": {
-    "cmd": ["/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD $file"],
-  },
-  "linux": {
-    "cmd": [ "openscad $file" ],
-  },
-  "windows": {
-    "cmd": ["openscad.com $file"],
-  },
-
-
-  "variants": [
-    {
-      "name": "PNG",
-      "osx": {
-        "cmd": [
-          "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD -o ${file/(.+)\\..+/$1/}.png $file"
-        ],
-      },
-      "linux": {
-        "cmd": [
-          "openscad -o ${file/(.+)\\..+/$1/}.png ${file}"
-        ],
-      },
-      "windows": {
-        "cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.png", "${file}"],
-      }
-    }, {
-      "name": "DXF",
-      "osx": {
-        "cmd": [
-          "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD -o ${file/(.+)\\..+/$1/}.dxf $file"
-        ],
-      },
-      "linux": {
-        "cmd": [
-          "openscad -o ${file/(.+)\\..+/$1/}.dxf ${file}"
-        ],
-      },
-      "windows": {
-        "cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.dxf", "${file}"],
-      }
-    }, {
-      "name": "STL",
-      "osx": {
-        "cmd": [
-          "/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD -o ${file/(.+)\\..+/$1/}.stl $file"
-        ],
-      },
-      "linux": {
-        "cmd": [
-          "openscad -o ${file/(.+)\\..+/$1/}.stl ${file}"
-        ],
-      },
-      "windows": {
-        "cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.stl", "${file}"],
-      }
-    }
-  ]
+	"variants": [
+		{
+			"name": "PNG",
+			"osx": {
+				"cmd": [
+					"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "${file/(.+)\\..+/$1/}.png", "$file"
+				],
+			},
+			"linux": {
+				"cmd": [
+					"openscad", "-o", "${file/(.+)\\..+/$1/}.png", "$file"
+				],
+			},
+			"windows": {
+				"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.png", "$file"],
+			}
+		}, {
+			"name": "DXF",
+			"osx": {
+				"cmd": [
+					"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "${file/(.+)\\..+/$1/}.dxf", "$file"
+				],
+			},
+			"linux": {
+				"cmd": [
+					"openscad", "-o", "${file/(.+)\\..+/$1/}.dxf", "$file"
+				],
+			},
+			"windows": {
+				"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.dxf", "$file"],
+			}
+		}, {
+			"name": "STL",
+			"osx": {
+				"cmd": [
+					"/Applications/OpenSCAD.app/Contents/MacOS/OpenSCAD", "-o", "${file/(.+)\\..+/$1/}.stl", "$file"
+				],
+			},
+			"linux": {
+				"cmd": [
+					"openscad", "-o", "${file/(.+)\\..+/$1/}.stl", "$file"
+				],
+			},
+			"windows": {
+				"cmd": ["openscad.com", "-o", "${file/(.+)\\..+/$1/}.stl", "$file"],
+			}
+		}
+	]
 }


### PR DESCRIPTION
Fixes: File paths with space characters on macOS cannot be opened by the build command. 
https://github.com/tralamazza/Sublime-OpenScad/issues/10